### PR TITLE
Use LTS instead of latest release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ before_script:
   - bundle exec rake db:schema:load
 install:
   - bundle install
-  - nvm install node
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh
+  - command -v nvm
+  - nvm install --lts
   - node -v
   - npm i -g yarn
   - yarn


### PR DESCRIPTION
Latest versions change more commonly than LTS versions, also, current LTS would work good with yarn without the `const` declaration issues